### PR TITLE
Add Dockerfile and docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+FLASK_APP=application
+FLASK_ENV=dev
+FLASK_RUN_HOST=0.0.0.0
+MAIL_DEBUG=true
+
+jwt_secret_key='XulhzbydxgvwRkPXnDeCoOw2VrE='
+secret_key='H78Pg7CalkDlf4A81YKDlKcax8c='

--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-FLASK_APP=application
-FLASK_ENV=dev
-FLASK_RUN_HOST=0.0.0.0
-MAIL_DEBUG=true
-
-jwt_secret_key='XulhzbydxgvwRkPXnDeCoOw2VrE='
-secret_key='H78Pg7CalkDlf4A81YKDlKcax8c='

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ library
 # Python
 __pycache__
 venv
-.env
 *.pyc
 
 # Database

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ library
 # Python
 __pycache__
 venv
+.env
 *.pyc
 
 # Database

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.5-alpine
+
+RUN apk update && \
+    apk add --no-cache \
+      gcc \
+      musl-dev \
+      npm \
+      postgresql-dev \
+      python3-dev
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+
+RUN pip install --upgrade pip && \
+    pip install --requirement requirements.txt
+
+COPY package.json package.json
+
+RUN npm install --global npm && \
+    npm update && \
+    npm install && \
+    npm run dev
+
+COPY . /app
+
+ENTRYPOINT [ "./entrypoint.sh" ]
+
+CMD [ "run" ]

--- a/Readme.md
+++ b/Readme.md
@@ -414,6 +414,13 @@ If you experience such errors:
 1. In the database remove the record from alembic_version table
 2. Remove any files from your computer under app/migrations.
 
+# Running with Docker
+1. Add or override necessary environment variables using `.env`.
+2. Run with `docker-compose`:
+```sh
+docker-compose up
+```
+
 ## Setting your own data
 ### Company name
 There are 2 places to set up your company name:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: '3.7'
+
+services:
+  db:
+    image: postgres:12.0-alpine
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: dev
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+
+  app:
+    build: .
+    depends_on:
+      - db
+    environment:
+      - db_url=postgres://postgres:password@db:5432/dev
+    ports:
+      - 5000:5000
+    volumes:
+      - .:/app
+
+volumes:
+  postgres_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,11 @@ services:
     depends_on:
       - db
     environment:
+      - FLASK_APP=${FLASK_APP:-application}
+      - FLASK_ENV=${FLASK_ENV:-dev}
+      - FLASK_RUN_HOST=${FLASK_RUN_HOST:-0.0.0.0}
+      - jwt_secret_key=${jwt_secret_key:-FAKE_JWT_SECRET_KEY}
+      - secret_key=${secret_key:-FAKE_SECRET_KEY}
       - db_url=postgres://postgres:password@db:5432/dev
     ports:
       - 5000:5000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+CMD=${1:-run}
+flask db upgrade
+flask "${CMD}"


### PR DESCRIPTION
## Overview
Allows developers to start the application using `docker-compose up`. Fixes #1.

## Demo
```bash
% docker-compose up 
Creating network "open-source-saas-boilerpate_default" with the default driver
Creating open-source-saas-boilerpate_db_1 ... done
Creating open-source-saas-boilerpate_app_1 ... done
Attaching to open-source-saas-boilerpate_db_1, open-source-saas-boilerpate_app_1
db_1   | 2020-01-10 01:41:55.909 UTC [1] LOG:  starting PostgreSQL 12.0 on x86_64-pc-linux-musl, compiled by gcc (Alpine 8.3.0) 8.3.0, 64-bit
db_1   | 2020-01-10 01:41:55.909 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
db_1   | 2020-01-10 01:41:55.909 UTC [1] LOG:  listening on IPv6 address "::", port 5432
db_1   | 2020-01-10 01:41:55.917 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
db_1   | 2020-01-10 01:41:55.933 UTC [18] LOG:  database system was shut down at 2020-01-10 01:34:24 UTC
db_1   | 2020-01-10 01:41:55.937 UTC [1] LOG:  database system is ready to accept connections
app_1  | INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
app_1  | INFO  [alembic.runtime.migration] Will assume transactional DDL.
app_1  |  * Serving Flask app "application"
app_1  |  * Environment: dev
app_1  |  * Debug mode: off
app_1  |  * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
```